### PR TITLE
Fixed orientation issues

### DIFF
--- a/CSNotificationView/CSNotificationView.m
+++ b/CSNotificationView/CSNotificationView.m
@@ -283,7 +283,7 @@ static NSInteger const kCSNotificationViewEmptySymbolViewTag = 666;
 //Workaround as there is a bug: sometimes, when accessing topLayoutGuide, it will render contentSize of UITableViewControllers to be {0, 0}
 - (CGFloat)topLayoutGuideLengthCalculation
 {
-    CGFloat top = CGRectGetHeight([[UIApplication sharedApplication] statusBarFrame]);
+    CGFloat top = MIN([UIApplication sharedApplication].statusBarFrame.size.height, [UIApplication sharedApplication].statusBarFrame.size.width);
     
     if (self.parentNavigationController) {
         


### PR DESCRIPTION
This should fix the orientation issues.  In landscape orientation on iPad, the statusBarFrame was returning 1024 as the height of the status bar making the notification huge and unusable.  This fix should grab the min of the height and width of the status bar.
