### PR TITLE
New quick presentation method for custom UIFont and NSTextAlignment

### DIFF
--- a/CSNotificationView/CSNotificationView.h
+++ b/CSNotificationView/CSNotificationView.h
@@ -31,6 +31,14 @@ typedef enum {
            message:(NSString*)message
           duration:(NSTimeInterval)duration;
 
++ (void)showInViewController:(UIViewController*)viewController
+                   tintColor:(UIColor*)tintColor
+                        font:(UIFont*)font
+               textAlignment:(NSTextAlignment)textAlignment
+                       image:(UIImage*)image
+                     message:(NSString*)message
+                    duration:(NSTimeInterval)duration;
+
 #pragma mark + creators
 
 + (CSNotificationView*)notificationViewWithParentViewController:(UIViewController*)viewController

--- a/CSNotificationView/CSNotificationView.m
+++ b/CSNotificationView/CSNotificationView.m
@@ -58,6 +58,34 @@ static NSString* const kCSNotificationViewUINavigationControllerWillShowViewCont
     
 }
 
++ (void)showInViewController:(UIViewController*)viewController
+                   tintColor:(UIColor*)tintColor
+                        font:(UIFont*)font
+               textAlignment:(NSTextAlignment)textAlignment
+                       image:(UIImage*)image
+                     message:(NSString*)message
+                    duration:(NSTimeInterval)duration
+{
+    NSAssert(message, @"'message' must not be nil.");
+    
+    __block CSNotificationView* note = [[CSNotificationView alloc] initWithParentViewController:viewController];
+    note.tintColor = tintColor;
+    note.image = image;
+    note.textLabel.font = font;
+    note.textLabel.textAlignment = textAlignment;
+    note.textLabel.text = message;
+    
+    void (^completion)() = ^{[note setVisible:NO animated:YES completion:nil];};
+    [note setVisible:YES animated:YES completion:^{
+        double delayInSeconds = duration;
+        dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
+        dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
+            completion();
+        });
+    }];
+    
+}
+
 + (void)showInViewController:(UIViewController *)viewController
              style:(CSNotificationViewStyle)style
            message:(NSString *)message


### PR DESCRIPTION
I needed to change the font and the text alignment of the notification label, so I've added an additional quick presentation method. Probably a little overkill to add another method, but I'm afraid everything else would break when people are already using it.
