### PR TITLE
Added tap handling via a callback block

### DIFF
--- a/CSNotificationView/CSNotificationView.h
+++ b/CSNotificationView/CSNotificationView.h
@@ -17,6 +17,8 @@ typedef enum {
     CSNotificationViewStyleError,
 } CSNotificationViewStyle;
 
+typedef void(^TapHandlerBlock)();
+
 @interface CSNotificationView : UIView
 
 #pragma mark + quick presentation
@@ -53,6 +55,7 @@ typedef enum {
 #pragma mark - presentation
 
 - (void)setVisible:(BOOL)showing animated:(BOOL)animated completion:(void (^)())completion;
+- (void)setVisible:(BOOL)showing animated:(BOOL)animated tapHandler:(TapHandlerBlock)tapHandler completion:(void (^)())completion;
 - (void)dismissWithStyle:(CSNotificationViewStyle)style message:(NSString*)message duration:(NSTimeInterval)duration animated:(BOOL)animated;
 @property (readonly, nonatomic, getter = isShowing) BOOL visible;
 

--- a/CSNotificationView/CSNotificationView.m
+++ b/CSNotificationView/CSNotificationView.m
@@ -28,6 +28,12 @@ static NSString* const kCSNotificationViewUINavigationControllerWillShowViewCont
 @property (nonatomic, strong) UILabel* textLabel;
 @property (nonatomic, strong) UIColor* contentColor;
 
+#pragma mark - interaction
+@property (nonatomic, strong) UITapGestureRecognizer* tapRecognizer;
+@property (nonatomic, copy) TapHandlerBlock tapHandler;
+
+-(void)handleTapInView;
+
 @end
 
 @implementation CSNotificationView
@@ -274,6 +280,15 @@ static NSString* const kCSNotificationViewUINavigationControllerWillShowViewCont
     self.contentColor = [self legibleTextColorForBlurTintColor:tintColor];
 }
 
+#pragma mark - interaction
+
+-(void)handleTapInView
+{
+    NSAssert(self.tapHandler != nil, @"Tap handler can't be nil!");
+    
+    self.tapHandler();
+}
+
 #pragma mark - presentation
 
 - (void)setVisible:(BOOL)visible animated:(BOOL)animated completion:(void (^)())completion
@@ -311,6 +326,27 @@ static NSString* const kCSNotificationViewUINavigationControllerWillShowViewCont
         _visible = visible;
     } else if (completion) {
         completion();
+    }
+}
+
+-(void)setVisible:(BOOL)showing animated:(BOOL)animated tapHandler:(TapHandlerBlock)tapHandler completion:(void (^)())completion
+{
+    [self setVisible:showing animated:animated completion:completion];
+    if (tapHandler) {
+        
+        if (nil == self.tapRecognizer)
+            self.tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTapInView)];
+        
+        self.tapHandler = tapHandler;
+        
+        //remove in the case of multiple calls != multiple handler calls
+        [self removeGestureRecognizer:self.tapRecognizer];
+        [self addGestureRecognizer:self.tapRecognizer];
+        self.userInteractionEnabled = YES;
+    }
+    else {
+        
+        [self removeGestureRecognizer:self.tapRecognizer];
     }
 }
 


### PR DESCRIPTION
Resolves #11 in what seems like the simplest way. An enhancement would be to make corresponding factory methods / designated initializers to handle, but for now you just call the new `-setVisible:animated:tapHandler:completion:` method.
