### PR TITLE
fix bundle image source of iOS 7

### DIFF
--- a/CSNotificationView/CSNotificationView.m
+++ b/CSNotificationView/CSNotificationView.m
@@ -521,10 +521,10 @@
     NSBundle *assetsBundle = [NSBundle bundleWithURL:[[NSBundle mainBundle] URLForResource:@"CSNotificationView" withExtension:@"bundle"]];
     switch (style) {
         case CSNotificationViewStyleSuccess:
-            matchedImage = [UIImage imageNamed:@"checkmark" inBundle:assetsBundle compatibleWithTraitCollection:nil];
+            matchedImage = [UIImage imageWithContentsOfFile:[assetsBundle pathForResource:@"checkmark" ofType:@"png"]];
             break;
         case CSNotificationViewStyleError:
-            matchedImage = [UIImage imageNamed:@"exclamationMark" inBundle:assetsBundle compatibleWithTraitCollection:nil];
+            matchedImage = [UIImage imageWithContentsOfFile:[assetsBundle pathForResource:@"exclamationMark" ofType:@"png"]];
             break;
         default:
             break;


### PR DESCRIPTION
When I update the library in the Cocoapods, I find that the app will crash because it can't get the correct image.
So I get the image in a different way. And it works fine in my device. (iPhone 5, iOS 7.0.4)
