### PR TITLE
Changed enum implementation to enable short syntax in Swift

### DIFF
--- a/CSNotificationView/CSNotificationView.h
+++ b/CSNotificationView/CSNotificationView.h
@@ -12,10 +12,10 @@ static CGFloat const kCSNotificationViewHeight = 50.0f;
 static CGFloat const kCSNotificationViewSymbolViewSidelength = 44.0f;
 static NSTimeInterval const kCSNotificationViewDefaultShowDuration = 2.0;
 
-typedef enum {
+typedef NS_ENUM(NSInteger, CSNotificationViewStyle) {
     CSNotificationViewStyleSuccess,
-    CSNotificationViewStyleError,
-} CSNotificationViewStyle;
+    CSNotificationViewStyleError
+};
 
 typedef void(^CSVoidBlock)();
 


### PR DESCRIPTION
Before I always needed to put the full name of a `CSNotificationViewStyle` in Swift which lead to very long names. Since Swift there's a shorter syntax which was introduced exactly for cases like this. In order to enable the shorter syntax it is needed to use the `NS_ENUM` method, which I have done with this pull request.

**Important:**
All clients using `CSNotificationViewStyle` in Swift must replace `CSNotificationViewStyleError` with `.Error` and `CSNotificationViewStyleSuccess` with `.Success` when updating to a version with this change.
