### PR TITLE
Attempt to fix #59, status bar height is not hard-coded anymore, but derived from topLayoutGuide.length

### DIFF
--- a/CSNotificationView/CSNotificationView.m
+++ b/CSNotificationView/CSNotificationView.m
@@ -379,10 +379,9 @@
 
 #pragma mark - frame calculation
 
-//Workaround as there is a bug: sometimes, when accessing topLayoutGuide, it will render contentSize of UITableViewControllers to be {0, 0}
-- (CGFloat)topLayoutGuideLengthCalculation
+- (CGFloat)topLayoutGuideLengthOfViewController:(UIViewController *)viewController
 {
-    CGFloat top = MIN([UIApplication sharedApplication].statusBarFrame.size.height, [UIApplication sharedApplication].statusBarFrame.size.width);
+    CGFloat top = [self topLayoutGuideOfViewController:viewController].length;
     
     if (self.parentNavigationController && !self.parentNavigationController.navigationBarHidden) {
         
@@ -390,6 +389,15 @@
     }
     
     return top;
+}
+
+- (id<UILayoutSupport>)topLayoutGuideOfViewController:(UIViewController *)viewController
+{
+    if (viewController.parentViewController && ![viewController.parentViewController isKindOfClass:UINavigationController.class]) {
+        return [self topLayoutGuideOfViewController:viewController.parentViewController];
+    } else {
+        return viewController.topLayoutGuide;
+    }
 }
 
 - (CGRect)visibleFrame
@@ -400,7 +408,7 @@
         return CGRectZero;
     }
     
-    CGFloat topLayoutGuideLength = [self topLayoutGuideLengthCalculation];
+    CGFloat topLayoutGuideLength = [self topLayoutGuideLengthOfViewController:viewController];
 
     CGSize transformedSize = CGSizeApplyAffineTransform(viewController.view.frame.size, viewController.view.transform);
     CGRect displayFrame = CGRectMake(0, 0, fabs(transformedSize.width),
@@ -417,7 +425,7 @@
         return CGRectZero;
     }
     
-    CGFloat topLayoutGuideLength = [self topLayoutGuideLengthCalculation];
+    CGFloat topLayoutGuideLength = [self topLayoutGuideLengthOfViewController:viewController];
 
     CGSize transformedSize = CGSizeApplyAffineTransform(viewController.view.frame.size, viewController.view.transform);
     CGRect offscreenFrame = CGRectMake(0, -kCSNotificationViewHeight - topLayoutGuideLength,

--- a/Example/CSNotificationViewDemo.xcodeproj/project.pbxproj
+++ b/Example/CSNotificationViewDemo.xcodeproj/project.pbxproj
@@ -323,6 +323,7 @@
 				GCC_PREFIX_HEADER = "CSNotificationViewDemo/CSNotificationViewDemo-Prefix.pch";
 				INFOPLIST_FILE = "CSNotificationViewDemo/CSNotificationViewDemo-Info.plist";
 				PRODUCT_NAME = CSNotificationViewDemo;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -337,6 +338,7 @@
 				GCC_PREFIX_HEADER = "CSNotificationViewDemo/CSNotificationViewDemo-Prefix.pch";
 				INFOPLIST_FILE = "CSNotificationViewDemo/CSNotificationViewDemo-Info.plist";
 				PRODUCT_NAME = CSNotificationViewDemo;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/Example/CSNotificationViewDemo/CSRootViewController.m
+++ b/Example/CSNotificationViewDemo/CSRootViewController.m
@@ -49,6 +49,7 @@
     modalController.view.backgroundColor = [UIColor whiteColor];
     modalController.navigationItem.title = @"Modal";
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:modalController];
+    navController.modalPresentationStyle = UIModalPresentationFormSheet;
     
     __weak UIViewController *weakModalController = modalController;
 


### PR DESCRIPTION
Not sure about this one. Well at least it works in my opinion, but I still don't understand that comment about that "workaround".

I could've just used `viewController.topLayoutGuide`, but I considered this: http://stackoverflow.com/a/21541533/1759462, because it should also work with nested child view controllers.

So what's that all about? `contentSize` of `UITableViewController` being rendered with `{0, 0}`. Do you have any test cases?

I've also changed the example project to a Universal App, so that you can see that the modal presentation also works properly.
