### PR TITLE
Provides means to use a custom symbol view

### DIFF
--- a/CSNotificationView/CSNotificationView.h
+++ b/CSNotificationView/CSNotificationView.h
@@ -108,4 +108,10 @@ typedef void(^CSVoidBlock)();
  */
 @property (nonatomic, copy) CSVoidBlock tapHandler;
 
+/*
+ * If given, this view will be used in place of the image or the activity view.
+ * The size of the symbol view will be adjusted automatically; 
+ * the setter should not set width/height constraints
+ */
+@property (nonatomic, strong) UIView* customSymbolView;
 @end

--- a/CSNotificationView/CSNotificationView.m
+++ b/CSNotificationView/CSNotificationView.m
@@ -439,7 +439,10 @@
 {
     [self.symbolView removeFromSuperview];
     
-    if (self.isShowingActivity) {
+    if (self.customSymbolView) {
+        _symbolView = self.customSymbolView;
+    }
+    else if (self.isShowingActivity) {
         UIActivityIndicatorView* indicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhite];
         indicator.color = self.contentColor;
         [indicator startAnimating];


### PR DESCRIPTION
Offers the user to use a custom symbol view in place of the activity indicator/icon/image.
